### PR TITLE
Add terraform version to stacks version command

### DIFF
--- a/docs/3.3.12. stacks version.md
+++ b/docs/3.3.12. stacks version.md
@@ -4,17 +4,18 @@
 ```
 Usage: stacks version
 
-  Print the Stacks and Python version numbers 
+  Print the Stacks, Python, and Terraform version numbers 
 ```
 
 ## Description
 
-  Print the Stacks and Python version numbers and exit
+  Print the Stacks, Python, and Terraform version numbers and exit
 
 ## Example
 
 ```shell
 $ stacks version
-Stacks 2.0.8
+Stacks 2.0.12
 Python 3.12.8
+Terraform 1.9.8
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stacks"
-version = "2.0.11"
+version = "2.0.12"
 description = "Stacks, the Terraform code pre-processor"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/stacks/main.py
+++ b/src/stacks/main.py
@@ -22,6 +22,8 @@ def cli():
 def version():
     print(f"Stacks {importlib.metadata.version('stacks')}")
     print(f"Python {platform.python_version()}")
+    terraform_output = helpers.run_command(cmd.config.TERRAFORM_PATH, "version", interactive=False)
+    print(f"Terraform {terraform_output.stdout.split('\n')[0].split(' ')[1][1:]}")
 
 
 @cli.command(hidden=True)  # hidden because it should not be used independently unless for advanced debugging purposes

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "stacks"
-version = "2.0.8"
+version = "2.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Description
Added terraform version to the `stacks version` output for an easy quick check when having multiple tf versions and/or changing the STACKS_TERRAFORM_VERSION variable. 

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
~~- [ ] Existing issues have been referenced (where applicable)~~
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
