### PR TITLE
Fix link to quick start guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It was initially presented and open-sourced at [SREcon23 Americas](https://www.u
 
 You can read "Terraform" and "OpenTofu" interchangeably, Stacks works with both but we've chosen to go with "Terraform" for readability.
 
-The ["I am starting from scratch" quick-start guide](<2.2. I am starting from scratch.md>) is a good introduction to Stacks and what it does.
+The ["I am starting from scratch" quick-start guide](<docs/2.2. I am starting from scratch.md>) is a good introduction to Stacks and what it does.
 
 
 ## Documentation


### PR DESCRIPTION
## Description

This PR fixes the link to the quick start guide in the introduction section of the `README.md` file.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

Checklist
- [x] I have read the [contributing guidelines](https://github.com/CONTRIBUTING.md)
- [x] ~Existing issues have been referenced (where applicable)~
  - I have verified this change is not present in other open pull requests
- [x] ~Functionality is documented~
- [x] ~All code style checks pass~
- [x] ~New code contribution is covered by automated tests~
- [x] ~All new and existing tests pass~
