### PR TITLE
Add Dockerfile with minimal supported Python version (3.10)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.10-slim
+
+RUN REQUIRED_PKGS=' \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+    ' \
+    && apt-get update \
+    && apt-get install --no-install-recommends --yes ${REQUIRED_PKGS} \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG ASDF_VERSION="v0.16.7"
+ENV ASDF_DATA_DIR="/opt/asdf-data"
+ENV ASDF_INSTALL_DIR="/opt/asdf"
+ENV PATH="${ASDF_DATA_DIR}/shims:${ASDF_INSTALL_DIR}/bin:${PATH}"
+
+RUN git clone \
+        --branch "${ASDF_VERSION}" \
+        --depth=1 \
+        https://github.com/asdf-vm/asdf.git "${ASDF_INSTALL_DIR}"  \
+    && asdf --help
+
+RUN asdf plugin add tfswitch \
+    && asdf install tfswitch latest \
+    && asdf global tfswitch latest \
+    && tfswitch --latest
+
+RUN apt-get update \
+    && pip install git+https://github.com/tchemineau/cisco-thousandeyes-stacks.git@provides-dockerfile \
+    && stacks --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "cryptography>=43.0.3",
     "deepmerge>=2.0",
     "gitpython>=3.1.43",
-    "importlib>=1.0.4",
     "jinja2>=3.1.4",
     "packaging>=24.2",
     "python-hcl2<6.0.0", # https://github.com/amplify-education/python-hcl2/issues/183


### PR DESCRIPTION
## Description

The idea is to provide a minimal `Dockerfile` to build a container image that can run `stacks` tool properly.

I would like to reuse that mechanism to eventually publish the container image to docker hub, and use it in the CI to do some more advanced testing.

For my use-case, I found out the result container image very useful to quickly run `stacks encrypt` command line.

Let me know your thought, and if that could be useful.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
