### PR TITLE
Fix deepmerge filter

### DIFF
--- a/src/stacks/filters/deepformat.py
+++ b/src/stacks/filters/deepformat.py
@@ -2,7 +2,7 @@ def deepformat(ctx, value, params):
     if isinstance(value, str):
         return value.format(**params)
     elif isinstance(value, list):
-        return [deepformat(item, params) for item in value]
+        return [deepformat(ctx, item, params) for item in value]
     elif isinstance(value, dict):
-        return {deepformat(key, params): deepformat(value, params) for key, value in value.items()}
+        return {deepformat(ctx, key, params): deepformat(ctx, value, params) for key, value in value.items()}
     return value


### PR DESCRIPTION
## Description

This PR fixes the `deepmerge` filter by passing the auto-injected `ctx` parameter when recursively calling `deepmerge`.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)