### PR TITLE
Add --from-stdin to stacks encrypt

### DIFF
--- a/docs/3.3.4. stacks encrypt.md
+++ b/docs/3.3.4. stacks encrypt.md
@@ -2,12 +2,13 @@
 
 ## Usage
 ```
-Usage: stacks encrypt [OPTIONS] STRING
+Usage: stacks encrypt [OPTIONS] [STRING]
 
   Encrypt a secret string using a public key. Can run in any directory.
 
 Options:
   --public-key-path TEXT  [required]
+  --from-stdin            Read input string from standard input
   --help                  Show this message and exit.
 ```
 

--- a/src/stacks/main.py
+++ b/src/stacks/main.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import pathlib
 import platform
+import sys
 
 import click
 
@@ -65,12 +66,19 @@ def genkey(public_key_path, private_key_path):
 
 @cli.command()
 @click.option("--public-key-path", required=True)
-@click.argument("string")
-def encrypt(public_key_path, string):
+@click.option("--from-stdin", is_flag=True, help="Read input string from standard input")
+@click.argument("string", required=False)
+def encrypt(public_key_path, from_stdin, string):
     """
     Encrypt a secret string using a public key.
     Can run in any directory.
     """
+    if from_stdin:
+        string = sys.stdin.read()
+        if not string:
+            raise click.ClickException("No input received from stdin.")
+    elif string is None:
+        raise click.ClickException("You must provide either a string argument or use --from-stdin.")
     print(helpers.encrypt(public_key_path=pathlib.Path(public_key_path), string=string))
 
 


### PR DESCRIPTION
## Description

In this PR we are implementing a new option flag `--from-stdin` for the `stacks encrypt` command. This will allow us to encrypt strings reading directly from stdin. Example:
```
cat ./secret.txt | stacks encrypt --public-key-path /path/to/public-key.pem --from-stdin
```
## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
