### PR TITLE
fix: Pin python-hcl2 dependency to 7.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "importlib>=1.0.4",
     "jinja2>=3.1.4",
     "packaging>=24.2",
-    "python-hcl2>=7.2.1",
+    "python-hcl2==7.2.1",
     "pyyaml>=6.0.2",
 ]
 


### PR DESCRIPTION
## Description

We are pining the `python-hcl2` version to `7.2.1`. The latest release has broken dependencies.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
